### PR TITLE
Remove unneeded Q_OBJECT declaration

### DIFF
--- a/src/phantom/phantomstyle.h
+++ b/src/phantom/phantomstyle.h
@@ -3,7 +3,6 @@
 
 class PhantomStylePrivate;
 class PhantomStyle : public QCommonStyle {
-  Q_OBJECT
 public:
   PhantomStyle();
   ~PhantomStyle();


### PR DESCRIPTION
moc features aren't used anywhere in that class, so this allows this code to work with moc-less codebases.