### PR TITLE
Fix a division by zero

### DIFF
--- a/src/phantom/phantomcolor.cpp
+++ b/src/phantom/phantomcolor.cpp
@@ -212,19 +212,29 @@ l2y(double l)
 static void
 xyz2luv(Triplet* in_out)
 {
-    double var_u = (4.0 * in_out->a) / (in_out->a + (15.0 * in_out->b) + (3.0 * in_out->c));
-    double var_v = (9.0 * in_out->b) / (in_out->a + (15.0 * in_out->b) + (3.0 * in_out->c));
-    double l = y2l(in_out->b);
-    double u = 13.0 * l * (var_u - ref_u);
-    double v = 13.0 * l * (var_v - ref_v);
+    double divisor = in_out->a + (15.0 * in_out->b) + (3.0 * in_out->c);
+    if(divisor != 0.)
+    {
+      double var_u = (4.0 * in_out->a) / divisor;
+      double var_v = (9.0 * in_out->b) / divisor;
+      double l = y2l(in_out->b);
+      double u = 13.0 * l * (var_u - ref_u);
+      double v = 13.0 * l * (var_v - ref_v);
 
-    in_out->a = l;
-    if(l < 0.00000001) {
-        in_out->b = 0.0;
-        in_out->c = 0.0;
-    } else {
-        in_out->b = u;
-        in_out->c = v;
+      in_out->a = l;
+      if(l < 0.00000001) {
+          in_out->b = 0.0;
+          in_out->c = 0.0;
+      } else {
+          in_out->b = u;
+          in_out->c = v;
+      }
+    }
+    else
+    {
+      in_out->a = 0.;
+      in_out->b = 0.;
+      in_out->c = 0.;
     }
 }
 


### PR DESCRIPTION
Running a -fsanitize=undefined build notified me of a division by zero (which can crash on some platforms) : 

```
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/jcelerier/score/3rdparty/phantomstyle/src/phantom/phantomcolor.cpp:215:38 in 
/home/jcelerier/score/3rdparty/phantomstyle/src/phantom/phantomcolor.cpp:216:38: runtime error: division by zero
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/jcelerier/score/3rdparty/phantomstyle/src/phantom/phantomcolor.cpp:216:38 in 
```

here's a fix - all the XYZ -> Luv converters I could find return (0,0,0) for such values in the XYZ colorspace