### PR TITLE
NEW: option to draw QGroupBox label on top of the frame (Windows-like)

### DIFF
--- a/src/phantom/phantomstyle.cpp
+++ b/src/phantom/phantomstyle.cpp
@@ -4762,7 +4762,7 @@ QRect PhantomStyle::subControlRect(ComplexControl control,
         // Testing against groupBox->features for the frame type doesn't seem
         // to work here.
         if (Ph::GroupBoxLabelOnFrame)
-          r.adjust(1, topMargin, -1, topMargin);
+          r.adjust(1, topMargin, -1, -topMargin);
         else
           r.adjust(1, 1, -1, -1);
       }


### PR DESCRIPTION
with the option toggled on:
![image](https://user-images.githubusercontent.com/182520/98519294-ddee5e00-2270-11eb-88c2-41e82ff9e030.png)

without:
![image](https://user-images.githubusercontent.com/182520/98519395-024a3a80-2271-11eb-80be-31240df344ef.png)
